### PR TITLE
Replace score parameter in sagePSM to sage_discriminant_score

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,5 @@ inst/scripts/sage_output
 inst/scripts/tmt2.json
 inst/scripts/sage_subset
 inst/scripts/tmt_subset.json
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,5 +31,5 @@ BugReports: https://github.com/UCLouvain-CBIO/sager/issues
 License: Artistic-2.0
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## sager 0.3.2
 
+- score param in `sagePSM()` is now `sage_discriminant_score` in line with its 
+corresponding fdr
 - fdr param in `sagePSM()` is now `spectrum_q`, in line with sage
   v0.13.0.
 

--- a/R/sagePSM.R
+++ b/R/sagePSM.R
@@ -26,7 +26,7 @@
 ##'     `"rank"`.
 ##'
 ##' @param score `character(1)` variable name that defines the
-##'     PSM score. default is `"hyperscore"`.
+##'     PSM score. default is `"sage_discriminant_score"`.
 ##'
 ##' @param fdr `character(1)` variable name that defines the spectrum
 ##'     FDR (or any relevant reliability score that can be used for
@@ -59,7 +59,7 @@ sagePSM <- function(idTable,
                     protein = "proteins",
                     decoy = "label",
                     rank = "rank",
-                    score = "hyperscore",
+                    score = "sage_discriminant_score",
                     fdr = "spectrum_q",
                     ...) {
     ## Get the identification data from input or from file

--- a/R/sager-package.R
+++ b/R/sager-package.R
@@ -30,7 +30,5 @@
 ##'   6478–6485 Publication Date:April 6, 2020
 ##'   [DOI:10.1021/acs.analchem.9b05685](https://doi.org/10.1021/acs.analchem.9b05685).
 ##'
-##' @docType package
-##'
 ##' @name sager
-NULL
+"_PACKAGE"

--- a/man/sagePSM.Rd
+++ b/man/sagePSM.Rd
@@ -11,7 +11,7 @@ sagePSM(
   protein = "proteins",
   decoy = "label",
   rank = "rank",
-  score = "hyperscore",
+  score = "sage_discriminant_score",
   fdr = "spectrum_q",
   ...
 )
@@ -38,7 +38,7 @@ rank of the peptide spectrum match in the PSM data. Default is
 \code{"rank"}.}
 
 \item{score}{\code{character(1)} variable name that defines the
-PSM score. default is \code{"hyperscore"}.}
+PSM score. default is \code{"sage_discriminant_score"}.}
 
 \item{fdr}{\code{character(1)} variable name that defines the spectrum
 FDR (or any relevant reliability score that can be used for

--- a/sager.Rproj
+++ b/sager.Rproj
@@ -1,0 +1,18 @@
+Version: 1.0
+ProjectId: caf7b0d4-37a7-4ec4-a910-1f14ba091fb9
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 4
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/vignettes/sager.Rmd
+++ b/vignettes/sager.Rmd
@@ -138,13 +138,13 @@ psm <- sagePSM(sagerIdData())
 psm
 ```
 
-Here we briefly visualise the hyperscore and spectrum FDR densities
+Here we briefly visualise the `sage_discriminant_score` and spectrum FDR densities
 for the forward and decoy/reverse hits:
 
 ```{r ggplot, message = FALSE}
 library(ggplot2)
 data.frame(psm) |>
-    ggplot(aes(x = hyperscore,
+    ggplot(aes(x = sage_discriminant_score,
                colour = label)) +
     geom_density()
 ```


### PR DESCRIPTION
Based off issue #4 : the `hyperscore` is here replaced by the `sage_discriminant_score` in the `score` parameter of `sagePSM()`

Changes include:
- Score parameter now accesses the `sage_discriminant_score` instead of the `hyperscore`
- The vignette is up to date in that regard
- Removed the deprecated `@docType package` and corrected the remaining documentation